### PR TITLE
Prevent sourcemap references comments in transpiled JavaScript files.

### DIFF
--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,6 +1,3 @@
 {
-  "extends": "../tsconfig.json",
-  "compilerOptions": {
-    "sourceMap": true
-  }
+  "extends": "../tsconfig.json"
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,8 +3,7 @@
     "inlineSources": false,
     "module": "commonjs",
     "moduleResolution": "node",
-    "target": "ES2017",
-    "sourceMap": true
+    "target": "ES2017"
   }
 }
 


### PR DESCRIPTION
Fix #229.