### PR TITLE
Remove method `ignore()` from the documentation as it does not exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,12 +93,3 @@ const buffer = Buffer.alloc(20);
   }
 })();
 ```
-
-If you have to skip a part of the data, you can use ignore:
-```js
-(async () => {
-  //...  
-  await streamReader.ignore(16);
-})();
-```
-


### PR DESCRIPTION
Fix: Borewit/peek-readable#293