### PR TITLE
Add Web Streams API support

### DIFF
--- a/.github/workflows/nodejs-ci.yml
+++ b/.github/workflows/nodejs-ci.yml
@@ -43,7 +43,6 @@ jobs:
             test/**/*.js.map
 
   test:
-
     runs-on: ubuntu-latest
     needs: build
 

--- a/.nycrc
+++ b/.nycrc
@@ -1,0 +1,17 @@
+{
+  "cache": false,
+  "check-coverage": false,
+  "extension": [
+    ".ts"
+  ],
+  "sourceMap": true,
+  "instrument": true,
+  "reporter": [
+        "lcov",
+        "text"
+  ],
+  "all": true,
+  "instrument": true,
+  "report-dir": "coverage",
+  "include": "lib/**/*.ts"
+}

--- a/lib/StreamReader.ts
+++ b/lib/StreamReader.ts
@@ -1,6 +1,7 @@
 import { Readable } from 'node:stream';
 import { EndOfStreamError } from './EndOfFileStream.js';
 import { Deferred } from './Deferred.js';
+import { IStreamReader } from "./index.js";
 
 export { EndOfStreamError } from './EndOfFileStream.js';
 
@@ -14,7 +15,7 @@ interface IReadRequest {
 
 const maxStreamReadSize = 1 * 1024 * 1024; // Maximum request length on read-stream operation
 
-export class StreamReader {
+export class StreamReader implements IStreamReader {
 
   /**
    * Deferred used for postponed read request (as not data is yet available to read)

--- a/lib/WebStreamReader.ts
+++ b/lib/WebStreamReader.ts
@@ -1,0 +1,58 @@
+// @ts-ignore
+import { ReadableStreamBYOBReader, ReadableStream } from 'node:stream/web';
+import { EndOfStreamError } from './EndOfFileStream.js';
+export { EndOfStreamError } from './EndOfFileStream.js';
+
+import type { IStreamReader } from "./index.js";
+
+/**
+ * Read from a WebStream
+ * Reference: https://nodejs.org/api/webstreams.html#class-readablestreambyobreader
+ */
+export class WebStreamReader implements IStreamReader {
+  private reader: ReadableStreamBYOBReader;
+  private peekQueue: Uint8Array[] = [];
+
+  public constructor(stream: ReadableStream<Uint8Array>) {
+    this.reader = stream.getReader({ mode: 'byob' }) as ReadableStreamBYOBReader;
+  }
+
+  public async peek(buffer: Uint8Array, offset: number, length: number): Promise<number> {
+    const bytesRead = await this.read(buffer, offset, length);
+    this.peekQueue.push(buffer.subarray(offset, offset + bytesRead));
+    return bytesRead;
+  }
+
+  public async read(buffer: Uint8Array, offset: number, length: number): Promise<number> {
+    if (length === 0) {
+      return 0;
+    }
+
+    if (this.peekQueue.length > 0) {
+      let bytesRead = 0;
+      while (this.peekQueue.length > 0 && bytesRead < length) {
+        const peeked = this.peekQueue.shift()!;
+        const toCopy = Math.min(peeked.length, length - bytesRead);
+        buffer.set(peeked.subarray(0, toCopy), offset + bytesRead);
+        bytesRead += toCopy;
+        if (toCopy < peeked.length) {
+          this.peekQueue.unshift(peeked.subarray(toCopy));
+        }
+      }
+      return bytesRead;
+    }
+
+    const result = await this.reader.read(new Uint8Array(length));
+
+    if (result.done) {
+      throw new EndOfStreamError();
+    }
+
+    if(result.value) {
+      buffer.set(result.value, offset);
+      return result.value.byteLength;
+    }
+
+    return 0;
+  }
+}

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,2 +1,7 @@
+export interface IStreamReader {
+  peek(uint8Array: Uint8Array, offset: number, length: number): Promise<number>;
+  read(buffer: Uint8Array, offset: number, length: number): Promise<number>
+}
 export { EndOfStreamError } from './EndOfFileStream.js';
 export { StreamReader } from './StreamReader.js';
+export { WebStreamReader } from './WebStreamReader.js';

--- a/test/examples.ts
+++ b/test/examples.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 
 import { assert } from 'chai';
-import fs from 'node:fs';
+import * as fs from 'node:fs';
 import { EndOfStreamError, StreamReader } from '../lib/index.js';
 
 describe('Examples', () => {

--- a/test/util.ts
+++ b/test/util.ts
@@ -1,9 +1,10 @@
 // Utilities for testing
 
 import { Readable } from 'node:stream';
+import { ReadableStream} from 'node:stream/web';
 
 /**
- * A mock readable-stream, using string to read from
+ * A mock Node.js readable-stream, using string to read from
  */
 export class SourceStream extends Readable {
 
@@ -19,4 +20,46 @@ export class SourceStream extends Readable {
     this.push(this.buf);
     this.push(null); // push the EOF-signaling `null` chunk
   }
+}
+
+
+// Function to convert a string to a BYOB ReadableStream
+function stringToBYOBStream(inputString: string): ReadableStream<Uint8Array> {
+  // Convert the string to a Uint8Array using TextEncoder
+  const encoder = new TextEncoder();
+  const uint8Array = encoder.encode(inputString);
+
+  let position = 0;
+
+  // Create a BYOBReadableStream
+  return new ReadableStream({
+    type: 'bytes',
+    async pull(controller) {
+      // Check if there is data left to be pushed
+      if (position < uint8Array.length) {
+        // Push the chunk to the controller
+        if (controller.byobRequest) {
+          const remaining = uint8Array.length - position;
+          // @ts-ignore
+          const v = controller.byobRequest.view;
+          const bytesRead = Math.min(remaining, v.byteLength);
+          v.set(uint8Array.subarray(position, position + bytesRead));
+          position += bytesRead;
+          // @ts-ignore
+          controller.byobRequest.respond(bytesRead);
+        } else {
+          controller.enqueue(uint8Array);
+          position = uint8Array.length;
+        }
+        if (position >= uint8Array.length) {
+          controller.close();
+        }
+      }
+    }
+  });
+}
+
+// Function to convert a string to a ReadableStreamBYOBReader
+export function stringToReadableStream(inputString: string): ReadableStream<Uint8Array> {
+  return stringToBYOBStream(inputString);
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "inlineSources": false,
     "module": "node16",
     "moduleResolution": "node16",
-    "target": "ES2019",
+    "target": "ES2020",
     "esModuleInterop": true,
     "strict": true
   }


### PR DESCRIPTION
Support Node.js [Web Streams API](https://nodejs.org/api/webstreams.html) supporting the [WHATWG Streams Standard](https://streams.spec.whatwg.org/) by introducing `WebStreamReader`.

Implements #353