### PR TITLE
Allow both DOM and Node.js web-byte-streams

### DIFF
--- a/lib/WebStreamReader.ts
+++ b/lib/WebStreamReader.ts
@@ -1,7 +1,9 @@
-import type { ReadableStreamBYOBReader, ReadableStream } from 'node:stream/web';
+import type { ReadableStream as NodeReadableStream, ReadableStreamBYOBReader } from 'node:stream/web';
 import { EndOfStreamError } from './EndOfStreamError.js';
 export { EndOfStreamError } from './EndOfStreamError.js';
 import { AbstractStreamReader } from "./AbstractStreamReader.js";
+
+export type AnyWebByteStream = NodeReadableStream<Uint8Array> | ReadableStream<Uint8Array>;
 
 /**
  * Read from a WebStream
@@ -10,7 +12,7 @@ import { AbstractStreamReader } from "./AbstractStreamReader.js";
 export class WebStreamReader extends AbstractStreamReader {
   private reader: ReadableStreamBYOBReader;
 
-  public constructor(stream: ReadableStream<Uint8Array>) {
+  public constructor(stream: AnyWebByteStream) {
     super();
     this.reader = stream.getReader({ mode: 'byob' }) as ReadableStreamBYOBReader;
   }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,4 +1,4 @@
 export { EndOfStreamError } from './EndOfStreamError.js';
 export { StreamReader } from './StreamReader.js';
-export { WebStreamReader } from './WebStreamReader.js';
+export { WebStreamReader, type AnyWebByteStream } from './WebStreamReader.js';
 export type { IStreamReader } from './AbstractStreamReader.js';


### PR DESCRIPTION
The typings for the DOM Web (byte) ReadableStream and the Node.js Web (byte) ReadableStream are slightly different. 
This PR allow the DOM Web (byte) ReadableStream in addition to the Node Web (byte) ReadableStream.

The combined type is exported as  `AnyWebByteStream`