### PR TITLE
CI: test with Bun (based on JavaScriptCore engine)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Node.js CI
+name: CI
 
 on:
   pull_request:
@@ -45,7 +45,8 @@ jobs:
             test/**/*.js
             test/**/*.js.map
 
-  test:
+  test-nodejs:
+    name: "Node.js"
     runs-on: ubuntu-latest
     needs: build
 
@@ -61,7 +62,7 @@ jobs:
       - name: 'Checkout the repository'
         uses: actions/checkout@v4
 
-      - name: Test with Node.js ${{ matrix.node-version }}
+      - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
@@ -77,18 +78,65 @@ jobs:
         with:
           name: build
 
-      - name: Test with Node.js ${{ matrix.node-version }}
+      - name: Unit tests with Node.js ${{ matrix.node-version }}
         run: yarn run test-coverage
 
       - name: Coveralls Parallel
         uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.github_token }}
-          flag-name: run-${{ matrix.test_number }}
+          flag-name: run-nodejs-${{ matrix.test_number }}
+          parallel: true
+
+
+
+  test-bun:
+    name: "Bun (JavaScriptCore)"
+    runs-on: ubuntu-latest
+    needs: build
+
+    strategy:
+      matrix:
+        bun-version: [1.2]
+
+    env:
+      YARN_IGNORE_NODE: 1
+
+    steps:
+
+      - name: 'Checkout the repository'
+        uses: actions/checkout@v4
+
+      - name: Setup Bun ${{ matrix.bun-version }}
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ matrix.bun-version }}
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install dependencies
+        run: yarn install
+
+      - name: Download build
+        uses: actions/download-artifact@v4
+        with:
+          name: build
+
+      - name: Unit tests with Bun ${{ matrix.bun-version }}
+        run: yarn run test-coverage
+
+      - name: Coveralls Parallel
+        uses: coverallsapp/github-action@v2
+        with:
+          github-token: ${{ secrets.github_token }}
+          flag-name: run-bun-${{ matrix.test_number }}
           parallel: true
 
   finish:
-    needs: test
+    needs:
+      - test-nodejs
+      - test-bun
     runs-on: ubuntu-latest
     steps:
       - name: Coveralls Finished

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The `peek-readable` contains one class: `StreamReader`, which reads from a [stre
 
 Module: version 5 migrated from [CommonJS](https://en.wikipedia.org/wiki/CommonJS) to [pure ECMAScript Module (ESM)](https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c).
 JavaScript is compliant with [ECMAScript 2019 (ES10)](https://en.wikipedia.org/wiki/ECMAScript#10th_Edition_%E2%80%93_ECMAScript_2019).
-Requires a modern browser or Node.js ≥ 18 engine.
+Requires a modern browser or Node.js ≥ 18 engine or Bun ≥ 1.2.
 
 For TypeScript CommonJs backward compatibility, you can use [load-esm](https://github.com/Borewit/load-esm).
 


### PR DESCRIPTION
Add integration for [Bum](https://bun.sh/) 1.2. As Bum is based on [JavaScriptCore](https://github.com/apple-opensource/JavaScriptCore), this also provides confidence there is compatibility with the Apple Safari web browser.

Thanks @jonluca for giving me this suggestion in https://github.com/Borewit/music-metadata/pull/2348

 