### PR TITLE
Avoid `close()` cancels the underlying Web stream

### DIFF
--- a/lib/WebStreamByobReader.ts
+++ b/lib/WebStreamByobReader.ts
@@ -1,15 +1,11 @@
-import type { ReadableStreamBYOBReader } from 'node:stream/web';
-import { AbstractStreamReader } from "./AbstractStreamReader.js";
+
+import { WebStreamReader } from './WebStreamReader.js';
 
 /**
  * Read from a WebStream using a BYOB reader
  * Reference: https://nodejs.org/api/webstreams.html#class-readablestreambyobreader
  */
-export class WebStreamByobReader extends AbstractStreamReader {
-
-  public constructor(private reader: ReadableStreamBYOBReader) {
-    super();
-  }
+export class WebStreamByobReader extends WebStreamReader {
 
   protected async readFromStream(buffer: Uint8Array, offset: number, length: number): Promise<number> {
 
@@ -25,14 +21,5 @@ export class WebStreamByobReader extends AbstractStreamReader {
     }
 
     return 0;
-  }
-
-  public abort(): Promise<void> {
-    return this.reader.cancel(); // Signals a loss of interest in the stream by a consumer
-  }
-
-  public async close(): Promise<void> {
-    await this.abort();
-    this.reader.releaseLock();
   }
 }

--- a/lib/WebStreamReader.ts
+++ b/lib/WebStreamReader.ts
@@ -1,0 +1,19 @@
+import type { ReadableStreamBYOBReader, ReadableStreamDefaultReader } from 'node:stream/web';
+import { AbstractStreamReader } from "./AbstractStreamReader.js";
+
+export abstract class WebStreamReader extends AbstractStreamReader {
+
+  public constructor(protected reader: ReadableStreamDefaultReader | ReadableStreamBYOBReader) {
+    super();
+  }
+
+  protected abstract readFromStream(buffer: Uint8Array, offset: number, length: number): Promise<number>;
+
+  public async abort(): Promise<void> {
+    return this.close();
+  }
+
+  public async close(): Promise<void> {
+    this.reader.releaseLock();
+  }
+}


### PR DESCRIPTION
Also moves common `abort()` and `close()` functionality to abstract super class.

Resolves https://github.com/sindresorhus/file-type/issues/734